### PR TITLE
Better handling of genres with spaces in their name

### DIFF
--- a/moddownloaderr
+++ b/moddownloaderr
@@ -305,7 +305,7 @@ do
         while [ -z "${possiblegenres[$GENRENUM]}" ]
         do
           read -p "> " GENRENUM
-          [ -z ${possiblegenres[$GENRENUM]} ] && printf '\e[A\e[K'
+          [ -z "${possiblegenres[$GENRENUM]}" ] && printf '\e[A\e[K'
         done
       fi
       [ $MDDEBUG ] && echo DEBUG genrenum: $GENRENUM


### PR DESCRIPTION
Genres with spaces in their name would make the script show errors like
```
./moddownloaderr: line 308: [: Electronic: binary operator expected
```