### PR TITLE
Create MODPATH if it doesn't exist

### DIFF
--- a/moddownloaderr
+++ b/moddownloaderr
@@ -189,6 +189,7 @@ set_modpath()
   CURRENTPATH=$(pwd)
   echo "Where do you want to save the mods?"
   read -p "> " -e -i $CURRENTPATH MODPATH
+  mkdir -p "$MODPATH"
   echo Download path has been set to: $MODPATH
   [ $MDDEBUG ] && echo
 }


### PR DESCRIPTION
This makes sure that the script doesn't throw tons of "No such file or directory" errors.